### PR TITLE
Resolução do problema do Javadoc

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/generate/NamedGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/NamedGraphGenerator.java
@@ -64,7 +64,7 @@ public class NamedGraphGenerator<V, E>
 
     /**
      * Generates a <a href="http://mathworld.wolfram.com/DoyleGraph.html">Doyle Graph</a>. The Doyle
-     * graph, sometimes also known as the Holt graph (Marušič et al. 2005), is the quartic symmetric
+     * graph, sometimes also known as the Holt graph (Marušic et al. 2005), is the quartic symmetric
      * graph on 27 nodes
      * 
      * @param targetGraph receives the generated edges and vertices; if this is non-empty on entry,
@@ -160,7 +160,7 @@ public class NamedGraphGenerator<V, E>
      * 
      * @return the Dürer Graph
      */
-    public static Graph<Integer, DefaultEdge> dürerGraph()
+    public static Graph<Integer, DefaultEdge> durerGraph()
     {
         return generalizedPetersenGraph(6, 2);
     }
@@ -174,7 +174,7 @@ public class NamedGraphGenerator<V, E>
      *        the result will be a disconnected graph since generated elements will not be connected
      *        to existing elements
      */
-    public void generateDürerGraph(Graph<V, E> targetGraph)
+    public void generateDurerGraph(Graph<V, E> targetGraph)
     {
         generateGeneralizedPetersenGraph(targetGraph, 6, 2);
     }
@@ -260,7 +260,7 @@ public class NamedGraphGenerator<V, E>
      * 
      * @return the Möbius-Kantor Graph
      */
-    public static Graph<Integer, DefaultEdge> möbiusKantorGraph()
+    public static Graph<Integer, DefaultEdge> mobiusKantorGraph()
     {
         return generalizedPetersenGraph(8, 3);
     }
@@ -274,7 +274,7 @@ public class NamedGraphGenerator<V, E>
      *        the result will be a disconnected graph since generated elements will not be connected
      *        to existing elements
      */
-    public void generateMöbiusKantorGraph(Graph<V, E> targetGraph)
+    public void generateMobiusKantorGraph(Graph<V, E> targetGraph)
     {
         generateGeneralizedPetersenGraph(targetGraph, 8, 3);
     }
@@ -468,14 +468,14 @@ public class NamedGraphGenerator<V, E>
      * 
      * @return the Grötzsch Graph
      */
-    public static Graph<Integer, DefaultEdge> grötzschGraph()
+    public static Graph<Integer, DefaultEdge> grotzschGraph()
     {
         Graph<Integer,
             DefaultEdge> g = GraphTypeBuilder
                 .undirected().allowingMultipleEdges(false).allowingSelfLoops(false)
                 .vertexSupplier(SupplierUtil.createIntegerSupplier()).edgeClass(DefaultEdge.class)
                 .buildGraph();
-        new NamedGraphGenerator<Integer, DefaultEdge>().generateGrötzschGraph(g);
+        new NamedGraphGenerator<Integer, DefaultEdge>().generateGrotzschGraph(g);
         return g;
     }
 
@@ -487,7 +487,7 @@ public class NamedGraphGenerator<V, E>
      *        the result will be a disconnected graph since generated elements will not be connected
      *        to existing elements
      */
-    public void generateGrötzschGraph(Graph<V, E> targetGraph)
+    public void generateGrotzschGraph(Graph<V, E> targetGraph)
     {
         vertexMap.clear();
         for (int i = 1; i < 6; i++)

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/LexBreadthFirstIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/LexBreadthFirstIterator.java
@@ -41,7 +41,7 @@ import org.jgrapht.util.CollectionUtil;
  * Iterator chooses vertex with lexicographically largest label and returns it. It breaks ties
  * arbitrarily. For more information on lexicographical BFS see the following article: Corneil D.G.
  * (2004) <a href="https://pdfs.semanticscholar.org/d4b5/a492f781f23a30773841ec79c46d2ec2eb9c.pdf">
- * <i>Lexicographic Breadth First Search – A Survey</i></a>. In: Hromkovič J., Nagl M., Westfechtel
+ * <i>Lexicographic Breadth First Search – A Survey</i></a>. In: Hromkovic J., Nagl M., Westfechtel
  * B. (eds) Graph-Theoretic Concepts in Computer Science. WG 2004. Lecture Notes in Computer
  * Science, vol 3353. Springer, Berlin, Heidelberg; and the following
  * paper:<a href="http://www.cse.iitd.ac.in/~naveen/courses/CSL851/uwaterloo.pdf"><i>CS 762:

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/GeneralizedPetersenGraphGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/GeneralizedPetersenGraphGeneratorTest.java
@@ -59,7 +59,7 @@ public class GeneralizedPetersenGraphGeneratorTest
     @Test
     public void testDuererGraphGraph()
     {
-        Graph<Integer, DefaultEdge> g = NamedGraphGenerator.dürerGraph();
+        Graph<Integer, DefaultEdge> g = NamedGraphGenerator.durerGraph();
         this.validateBasics(g, 12, 18, 3, 4, 3);
         assertTrue(GraphTests.isCubic(g));
     }
@@ -93,7 +93,7 @@ public class GeneralizedPetersenGraphGeneratorTest
     @Test
     public void testMoebiusKantorGraph()
     {
-        Graph<Integer, DefaultEdge> g = NamedGraphGenerator.möbiusKantorGraph();
+        Graph<Integer, DefaultEdge> g = NamedGraphGenerator.mobiusKantorGraph();
         this.validateBasics(g, 16, 24, 4, 4, 6);
         assertTrue(GraphTests.isCubic(g));
         assertTrue(GraphTests.isBipartite(g));

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/NamedGraphGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/NamedGraphGeneratorTest.java
@@ -79,7 +79,7 @@ public class NamedGraphGeneratorTest
     @Test
     public void testGroetzschGraph()
     {
-        Graph<Integer, DefaultEdge> g = NamedGraphGenerator.grötzschGraph();
+        Graph<Integer, DefaultEdge> g = NamedGraphGenerator.grotzschGraph();
         this.validateBasics(g, 11, 20, 2, 2, 4);
     }
 


### PR DESCRIPTION
Erros eram devido ao uso de caractéres não reconhecidos pelo Javadoc, como por exemplo "ö". Ao gerar ainda dá 5 erros devido a tags de HTML não reconhecidas mas gera o documento na mesma.