### PR TITLE
Maven compila sem problemas e Javadoc sem necessidade de comentar linhas no module-info

### DIFF
--- a/jgrapht-core/src/main/java/module-info.java
+++ b/jgrapht-core/src/main/java/module-info.java
@@ -42,6 +42,6 @@ module org.jgrapht.core
     exports org.jgrapht.traverse;
     exports org.jgrapht.util;
 
-    //requires transitive org.jheaps;
-    //requires transitive org.apfloat;
+    requires transitive org.jheaps;
+    requires transitive org.apfloat;
 }


### PR DESCRIPTION
Devido à linha comentada "requires transitive org.jheaps" no module-info, o maven não fazia compile.